### PR TITLE
rename json types and modref.{state => persist}

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ class FunctionRef {
 
   toJSON (includeParams = true) {
     const json = {
-      type: 'func',
+      type: 'funcref',
       actorID: this.actorID.toJSON(),
       private: this.identifier ? this.identifier[0] : null,
       name: this.identifier ? this.identifier[1] : null,
@@ -164,14 +164,14 @@ class ActorRef {
 
   toJSON (includeExports = true) {
     return {
-      type: 'actor',
+      type: 'actorref',
       id: this.id.toJSON(),
-      mod: this.modRef.toJSON(includeExports)
+      modref: this.modRef.toJSON(includeExports)
     }
   }
 
   static fromJSON (data) {
-    return new ActorRef(ID.fromJSON(data.id), ModuleRef.fromJSON(data.mod))
+    return new ActorRef(ID.fromJSON(data.id), ModuleRef.fromJSON(data.modref))
   }
 
   encodeCBOR (gen) {
@@ -187,24 +187,24 @@ class ModuleRef {
    * @param {ID} id - the id of the module
    * @param {Number} type - type id of the module
    * @param {Object} exports - a map of exported function to params for the function, if any
-   * @param {Object} state - state of the module
+   * @param {Object} persist - persist of the module
    * @param {Buffer} code - code of the module
    */
-  constructor (id, type, exports, state, code) {
+  constructor (id, type, exports, persist, code) {
     this.id = id
     this.type = type
     this.exports = exports
-    this.state = state
+    this.persist = persist
     this.code = {'/': code}
   }
 
   toJSON (includeParams = true) {
     const json = {
-      type: 'mod',
+      type: 'modref',
       id: this.id.toJSON(),
       modType: this.type,
       code: this.code['/'] ? `0x${this.code['/'].toString('hex')}` : null,
-      state: this.state
+      persist: this.persist
     }
     if (includeParams) {
       json.exports = this.exports
@@ -213,11 +213,11 @@ class ModuleRef {
   }
 
   static fromJSON (data) {
-    return new ModuleRef(ID.fromJSON(data.id), data.modType, data.exports, data.state, Buffer.from(data.code.slice(2), 'hex'))
+    return new ModuleRef(ID.fromJSON(data.id), data.modType, data.exports, data.persist, Buffer.from(data.code.slice(2), 'hex'))
   }
 
   encodeCBOR (gen) {
-    return gen.write(new cbor.Tagged(TAGS.mod, [this.id, this.type, this.exports, this.state, this.code]))
+    return gen.write(new cbor.Tagged(TAGS.mod, [this.id, this.type, this.exports, this.persist, this.code]))
   }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -93,10 +93,10 @@ tape('utils', t => {
     Buffer.from([1, 2, 3, 4])
   ]
   const json = utils.toJSON(obj)
-  t.deepEquals(JSON.stringify(json), '[{"type":"mod","id":"0x01","modType":1,"code":"0x636f6465","state":[],"exports":{"name":["i32"]}},{"type":"actor","id":"0x02","mod":{"type":"mod","id":"0x01","modType":1,"code":"0x636f6465","state":[],"exports":{"name":["i32"]}}},{"type":"func","actorID":"0x02","private":false,"name":"main","gas":100,"params":["i32"]},"0x01020304"]')
+  t.deepEquals(JSON.stringify(json), '[{"type":"modref","id":"0x01","modType":1,"code":"0x636f6465","persist":[],"exports":{"name":["i32"]}},{"type":"actorref","id":"0x02","modref":{"type":"modref","id":"0x01","modType":1,"code":"0x636f6465","persist":[],"exports":{"name":["i32"]}}},{"type":"funcref","actorID":"0x02","private":false,"name":"main","gas":100,"params":["i32"]},"0x01020304"]')
 
   const jsonPartial = utils.toJSON(obj, false)
-  t.deepEquals(JSON.stringify(jsonPartial), '[{"type":"mod","id":"0x01","modType":1,"code":"0x636f6465","state":[]},{"type":"actor","id":"0x02","mod":{"type":"mod","id":"0x01","modType":1,"code":"0x636f6465","state":[]}},{"type":"func","actorID":"0x02","private":false,"name":"main","gas":100},"0x01020304"]')
+  t.deepEquals(JSON.stringify(jsonPartial), '[{"type":"modref","id":"0x01","modType":1,"code":"0x636f6465","persist":[]},{"type":"actorref","id":"0x02","modref":{"type":"modref","id":"0x01","modType":1,"code":"0x636f6465","persist":[]}},{"type":"funcref","actorID":"0x02","private":false,"name":"main","gas":100},"0x01020304"]')
 
   const modRefPartial = new objects.ModuleRef(id, 1, undefined, [], Buffer.from('code'))
   const objPartial = [

--- a/utils.js
+++ b/utils.js
@@ -40,11 +40,11 @@ const fromJSON = arg => {
     }
 
     switch (arg.type) {
-      case 'func':
+      case 'funcref':
         return FunctionRef.fromJSON(arg)
-      case 'actor':
+      case 'actorref':
         return ActorRef.fromJSON(arg)
-      case 'mod':
+      case 'modref':
         return ModuleRef.fromJSON(arg)
     }
   }


### PR DESCRIPTION
`modref.state` is a bit misleading since they're stateless, and that field is only use to initialize persistence